### PR TITLE
Fix search debounce functionality

### DIFF
--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getCharacters, searchCharacters, Character } from "@/lib/api";
+import { useDebounce } from "@/lib/hooks";
 import Image from "next/image";
 import { Search, ArrowLeft } from "lucide-react";
 import Link from "next/link";
@@ -22,7 +23,7 @@ interface ApiResponse {
 
 function CharactersList() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 500);
   const { ref, inView } = useInView();
 
   const {
@@ -53,9 +54,6 @@ function CharactersList() {
 
   const handleSearch = (value: string) => {
     setSearchTerm(value);
-    setTimeout(() => {
-      setDebouncedSearch(value);
-    }, 500);
   };
 
   if (isLoading) {

--- a/src/app/episodes/page.tsx
+++ b/src/app/episodes/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getEpisodes, searchEpisodes, Episode } from "@/lib/api";
+import { useDebounce } from "@/lib/hooks";
 import { Search, ArrowLeft } from "lucide-react";
 import QueryProvider from "@/components/query-provider";
 import Link from "next/link";
@@ -21,7 +22,7 @@ interface ApiResponse {
 
 function EpisodesList() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 500);
   const { ref, inView } = useInView();
 
   const {
@@ -52,9 +53,6 @@ function EpisodesList() {
 
   const handleSearch = (value: string) => {
     setSearchTerm(value);
-    setTimeout(() => {
-      setDebouncedSearch(value);
-    }, 500);
   };
 
   if (isLoading) {

--- a/src/app/locations/page.tsx
+++ b/src/app/locations/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getLocations, searchLocations, Location } from "@/lib/api";
+import { useDebounce } from "@/lib/hooks";
 import { Search, ArrowLeft } from "lucide-react";
 import QueryProvider from "@/components/query-provider";
 import Link from "next/link";
@@ -21,7 +22,7 @@ interface ApiResponse {
 
 function LocationsList() {
   const [searchTerm, setSearchTerm] = useState("");
-  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const debouncedSearch = useDebounce(searchTerm, 500);
   const { ref, inView } = useInView();
 
   const {
@@ -52,9 +53,6 @@ function LocationsList() {
 
   const handleSearch = (value: string) => {
     setSearchTerm(value);
-    setTimeout(() => {
-      setDebouncedSearch(value);
-    }, 500);
   };
 
   if (isLoading) {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,0 +1,25 @@
+import { useState, useEffect } from "react";
+
+/**
+ * A hook that returns a debounced value that only updates after the specified delay
+ * @param value The value to debounce
+ * @param delay The delay in milliseconds before updating the debounced value
+ * @returns The debounced value
+ */
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    // Set a timeout to update the debounced value after the specified delay
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    // Clean up the timeout if value changes or component unmounts
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}


### PR DESCRIPTION
## Description
This PR fixes issue #1 where the search debounce functionality wasn't working properly, causing searches to be triggered on every keystroke instead of waiting for the user to stop typing.

## Changes
- Created a reusable `useDebounce` hook in `src/lib/hooks.ts`
- Updated the search implementation in all three listing pages:
  - Characters page
  - Locations page
  - Episodes page

## Implementation Details
Instead of using the previous approach with `setTimeout` that didn't properly clear previous timeouts, this implementation:

1. Uses React's `useEffect` to manage the debounce timer
2. Properly cleans up previous timers when new inputs occur
3. Makes the code more maintainable with a reusable hook
4. Follows React best practices

## Testing
The changes have been tested and confirmed to:
- Only trigger searches after 500ms of user inactivity
- Clean up previous timeouts properly
- Work consistently across all list pages

Closes #1