### PR TITLE
Replace Next.js Image components with standard HTML img tags

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,11 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    rules: {
+      "@next/next/no-img-element": "off",
+    },
+  },
 ];
 
 export default eslintConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,14 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'rickandmortyapi.com',
-        pathname: '/api/character/avatar/**',
-      },
-    ],
-  },
   typescript: {
     // !! WARN !!
     // Dangerously allow type errors to pass for build

--- a/src/app/characters/[id]/page.tsx
+++ b/src/app/characters/[id]/page.tsx
@@ -1,6 +1,6 @@
 import { getCharacter } from "@/lib/api";
 import { notFound } from "next/navigation";
-import Image from "next/image";
+
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 
@@ -29,11 +29,10 @@ export default async function Page({
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
         <div className="relative aspect-square overflow-hidden border-4 border-black">
-          <Image
+          <img
             src={character.image}
             alt={character.name}
-            fill
-            className="object-cover"
+            className="object-cover w-full h-full"
           />
         </div>
 

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { getCharacters, searchCharacters, Character } from "@/lib/api";
 import { useDebounce } from "@/lib/hooks";
-import Image from "next/image";
+
 import { Search, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import QueryProvider from "@/components/query-provider";
@@ -112,11 +112,10 @@ function CharactersList() {
               className="brutalist-card group flex flex-col"
             >
               <div className="relative aspect-square mb-4 overflow-hidden border-4 border-black w-full">
-                <Image
+                <img
                   src={character.image}
                   alt={character.name}
-                  fill
-                  className="object-cover"
+                  className="object-cover w-full h-full"
                 />
               </div>
               <div className="flex-1">


### PR DESCRIPTION
## Replace Next.js Image components with standard HTML img tags

### Summary
Disabled the ESLint rule enforcing Next.js Image component usage and replaced all `<Image>` components with standard HTML `<img>` tags throughout the application.

### Changes Made
- **ESLint Config**: Disabled `@next/next/no-img-element` rule in `eslint.config.mjs`
- **Characters Page**: Replaced `<Image>` with `<img>` in character grid view
- **Character Detail Page**: Replaced `<Image>` with `<img>` in character profile view
- **Next.js Config**: Removed unnecessary `images.remotePatterns` configuration